### PR TITLE
update to use 0.0.2 tag

### DIFF
--- a/basic-sink/Makefile
+++ b/basic-sink/Makefile
@@ -1,6 +1,6 @@
 # this is the latest tag that has been pushed
 # if changes are made to the service, this tag should be updated before pushing
-TAG ?= 0.0.1
+TAG ?= 0.0.2
 
 .PHONY: docker-local server
 all: server docker-local

--- a/basic-sink/resources/extproc.yaml
+++ b/basic-sink/resources/extproc.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: ext-proc-grpc
-          image: gcr.io/solo-test-236622/ext-proc-example-basic-sink:0.0.1
+          image: gcr.io/solo-test-236622/ext-proc-example-basic-sink:0.0.2
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 18080


### PR DESCRIPTION
update default image tag to 0.0.2 which uses the raw header value that envoy now uses